### PR TITLE
Enable Fee Validity for existing patients

### DIFF
--- a/healthcare/healthcare/doctype/fee_validity/fee_validity.json
+++ b/healthcare/healthcare/doctype/fee_validity/fee_validity.json
@@ -2,7 +2,6 @@
  "actions": [],
  "allow_copy": 1,
  "allow_import": 1,
- "beta": 0,
  "creation": "2017-01-05 10:56:29.564806",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -11,9 +10,11 @@
  "field_order": [
   "practitioner",
   "patient",
+  "medical_department",
   "column_break_3",
   "status",
-  "section_break_5",
+  "patient_appointment",
+  "sales_invoice_ref",
   "section_break_3",
   "max_visits",
   "visited",
@@ -81,7 +82,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Completed\nPending",
+   "options": "Active\nExpired\nCompleted\nCancelled",
    "read_only": 1
   },
   {
@@ -99,14 +100,30 @@
    "read_only": 1
   },
   {
-   "collapsible": 1,
-   "fieldname": "section_break_5",
-   "fieldtype": "Section Break"
+   "fieldname": "medical_department",
+   "fieldtype": "Link",
+   "label": "Medical Department",
+   "options": "Medical Department",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sales_invoice_ref",
+   "fieldtype": "Link",
+   "label": "Sales Invoice Reference",
+   "options": "Sales Invoice",
+   "read_only": 1
+  },
+  {
+   "fieldname": "patient_appointment",
+   "fieldtype": "Link",
+   "label": "Patient Appointment",
+   "options": "Patient Appointment",
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2021-08-26 10:51:05.609349",
+ "modified": "2023-04-09 10:40:36.311443",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Fee Validity",
@@ -130,5 +147,6 @@
  "search_fields": "practitioner, patient",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "practitioner"
 }

--- a/healthcare/healthcare/doctype/fee_validity/fee_validity_list.js
+++ b/healthcare/healthcare/doctype/fee_validity/fee_validity_list.js
@@ -1,0 +1,12 @@
+frappe.listview_settings['Fee Validity'] = {
+	add_fields: ['practitioner', 'patient', 'status', 'valid_till'],
+	get_indicator: function (doc) {
+		const color = {
+			'Active': 'green',
+			'Completed': 'green',
+			'Expired': 'red',
+			'Cancelled': 'red'
+		};
+		return [__(doc.status), color[doc.status], "status,=," + doc.status];
+	}
+}

--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -132,6 +132,7 @@ scheduler_events = {
 	],
 	"daily": [
 		"healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_appointment_status",
+		"healthcare.healthcare.doctype.fee_validity.fee_validity.update_validity_status",
 	],
 }
 

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -1,3 +1,4 @@
 healthcare.patches.v0_0.setup_abdm_custom_fields
 healthcare.patches.v0_0.set_medical_code_from_field_to_codification_table
 healthcare.patches.v15_0.check_version_compatibility_with_frappe
+healthcare.patches.v15_0.set_fee_validity_status

--- a/healthcare/patches/v15_0/set_fee_validity_status.py
+++ b/healthcare/patches/v15_0/set_fee_validity_status.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	validities = frappe.db.get_all("Fee Validity", {"status": "Pending"}, as_list=0)
+
+	for fee_validity in validities:
+		frappe.db.set_value("Fee Validity", fee_validity, "status", "Active")


### PR DESCRIPTION
- Insert new Fee Validity for existing patient if not within fee validity
- Status changed to Active(Having free visits left), Expired, Completed (Max visits reached), Cancelled (Appointment Cancelled)
- Scheduler will update the status daily
- First invoiced appointment cancel will cancel fee validity
- Rescheduling the invoiced appointment will update linked fee validity
- Rescheduling the free visit appointment to outside fee validity will Invoice and insert new fee validity