### PR TITLE
Enable Fee Validity for existing patients

### DIFF
--- a/healthcare/healthcare/doctype/fee_validity/fee_validity.json
+++ b/healthcare/healthcare/doctype/fee_validity/fee_validity.json
@@ -2,7 +2,6 @@
  "actions": [],
  "allow_copy": 1,
  "allow_import": 1,
- "beta": 0,
  "creation": "2017-01-05 10:56:29.564806",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -11,9 +10,11 @@
  "field_order": [
   "practitioner",
   "patient",
+  "medical_department",
   "column_break_3",
   "status",
-  "section_break_5",
+  "patient_appointment",
+  "sales_invoice_ref",
   "section_break_3",
   "max_visits",
   "visited",
@@ -81,7 +82,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Completed\nPending",
+   "options": "Active\nExpired\nCompleted\nCancelled",
    "read_only": 1
   },
   {
@@ -99,14 +100,30 @@
    "read_only": 1
   },
   {
-   "collapsible": 1,
-   "fieldname": "section_break_5",
-   "fieldtype": "Section Break"
+   "fieldname": "medical_department",
+   "fieldtype": "Link",
+   "label": "Medical Department",
+   "options": "Medical Department",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sales_invoice_ref",
+   "fieldtype": "Link",
+   "label": "Sales Invoice Reference",
+   "options": "Sales Invoice",
+   "read_only": 1
+  },
+  {
+   "fieldname": "patient_appointment",
+   "fieldtype": "Link",
+   "label": "Patient Appointment",
+   "options": "Patient Appointment",
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "links": [],
- "modified": "2021-08-26 10:51:05.609349",
+ "modified": "2023-04-09 10:40:36.311443",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Fee Validity",
@@ -130,5 +147,6 @@
  "search_fields": "practitioner, patient",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "practitioner"
 }

--- a/healthcare/healthcare/doctype/fee_validity/fee_validity.py
+++ b/healthcare/healthcare/doctype/fee_validity/fee_validity.py
@@ -2,8 +2,8 @@
 # Copyright (c) 2015, ESS LLP and contributors
 # For license information, please see license.txt
 
-
 import datetime
+import json
 
 import frappe
 from frappe.model.document import Document
@@ -15,19 +15,26 @@ class FeeValidity(Document):
 		self.update_status()
 
 	def update_status(self):
-		if self.visited >= self.max_visits:
+		if getdate(self.valid_till) < getdate():
+			self.status = "Expired"
+		elif self.visited == self.max_visits:
 			self.status = "Completed"
 		else:
-			self.status = "Pending"
+			self.status = "Active"
 
 
 def create_fee_validity(appointment):
-	if not check_is_new_patient(appointment):
+	if patient_has_validity(appointment):
 		return
 
 	fee_validity = frappe.new_doc("Fee Validity")
 	fee_validity.practitioner = appointment.practitioner
 	fee_validity.patient = appointment.patient
+	fee_validity.medical_department = appointment.department
+	fee_validity.patient_appointment = appointment.name
+	fee_validity.sales_invoice_ref = frappe.db.get_value(
+		"Sales Invoice Item", {"reference_dn": appointment.name}, "parent"
+	)
 	fee_validity.max_visits = frappe.db.get_single_value("Healthcare Settings", "max_visits") or 1
 	valid_days = frappe.db.get_single_value("Healthcare Settings", "valid_days") or 1
 	fee_validity.visited = 0
@@ -39,22 +46,146 @@ def create_fee_validity(appointment):
 	return fee_validity
 
 
-def check_is_new_patient(appointment):
+def patient_has_validity(appointment):
 	validity_exists = frappe.db.exists(
-		"Fee Validity", {"practitioner": appointment.practitioner, "patient": appointment.patient}
-	)
-	if validity_exists:
-		return False
-
-	appointment_exists = frappe.db.get_all(
-		"Patient Appointment",
+		"Fee Validity",
 		{
-			"name": ("!=", appointment.name),
-			"status": ("!=", "Cancelled"),
-			"patient": appointment.patient,
 			"practitioner": appointment.practitioner,
+			"patient": appointment.patient,
+			"status": "Active",
+			"valid_till": [">=", appointment.appointment_date],
+			"start_date": ["<=", appointment.appointment_date],
 		},
 	)
-	if len(appointment_exists) and appointment_exists[0]:
-		return False
-	return True
+
+	return validity_exists
+
+
+@frappe.whitelist()
+def check_fee_validity(appointment, date=None, practitioner=None):
+	if not frappe.db.get_single_value("Healthcare Settings", "enable_free_follow_ups"):
+		return
+
+	if isinstance(appointment, str):
+		appointment = json.loads(appointment)
+		appointment = frappe.get_doc(appointment)
+
+	date = getdate(date) if date else appointment.appointment_date
+
+	filters = {
+		"practitioner": practitioner if practitioner else appointment.practitioner,
+		"patient": appointment.patient,
+		"valid_till": (">=", date),
+		"start_date": ("<=", date),
+	}
+	if appointment.status != "Cancelled":
+		filters["status"] = "Active"
+
+	validity = frappe.db.exists(
+		"Fee Validity",
+		filters,
+	)
+
+	if not validity:
+		# return valid fee validity when rescheduling appointment
+		if appointment.get("__islocal"):
+			return
+		else:
+			validity = get_fee_validity(appointment.get("name"), date) or None
+			if validity:
+				return validity
+		return
+
+	validity = frappe.get_doc("Fee Validity", validity)
+	return validity
+
+
+def manage_fee_validity(appointment):
+	free_follow_ups = frappe.db.get_single_value("Healthcare Settings", "enable_free_follow_ups")
+	# Update fee validity dates when rescheduling an invoiced appointment
+	if free_follow_ups:
+		invoiced_fee_validity = frappe.db.exists(
+			"Fee Validity", {"patient_appointment": appointment.name}
+		)
+		if invoiced_fee_validity and appointment.invoiced:
+			start_date = frappe.db.get_value("Fee Validity", invoiced_fee_validity, "start_date")
+			if getdate(appointment.appointment_date) != start_date:
+				frappe.db.set_value(
+					"Fee Validity",
+					invoiced_fee_validity,
+					{
+						"start_date": appointment.appointment_date,
+						"valid_till": getdate(appointment.appointment_date)
+						+ datetime.timedelta(
+							days=int(frappe.db.get_single_value("Healthcare Settings", "valid_days") or 1)
+						),
+					},
+				)
+
+	fee_validity = check_fee_validity(appointment)
+
+	if fee_validity:
+		exists = frappe.db.exists("Fee Validity Reference", {"appointment": appointment.name})
+		if appointment.status == "Cancelled" and fee_validity.visited > 0:
+			fee_validity.visited -= 1
+			frappe.db.delete("Fee Validity Reference", {"appointment": appointment.name})
+		elif fee_validity.status != "Active":
+			return
+		elif appointment.name != fee_validity.patient_appointment and not exists:
+			fee_validity.visited += 1
+			fee_validity.append("ref_appointments", {"appointment": appointment.name})
+		fee_validity.save(ignore_permissions=True)
+	else:
+		# remove appointment from fee validity reference when rescheduling an appointment to date not in fee validity
+		free_visit_validity = frappe.db.get_value(
+			"Fee Validity Reference", {"appointment": appointment.name}, "parent"
+		)
+		if free_visit_validity:
+			fee_validity = frappe.get_doc(
+				"Fee Validity",
+				free_visit_validity,
+			)
+			if fee_validity:
+				frappe.db.delete("Fee Validity Reference", {"appointment": appointment.name})
+				if fee_validity.visited > 0:
+					fee_validity.visited -= 1
+					fee_validity.save(ignore_permissions=True)
+		fee_validity = create_fee_validity(appointment)
+	return fee_validity
+
+
+@frappe.whitelist()
+def get_fee_validity(appointment_name, date):
+	"""
+	Get the fee validity details for the free visit appointment
+	:params appointment_name: Appointment doc name
+	:params date: Schedule date
+	:return fee validity name and valid_till values of free visit appointments
+	"""
+	if appointment_name:
+		appointment_doc = frappe.get_doc("Patient Appointment", appointment_name)
+	fee_validity = frappe.qb.DocType("Fee Validity")
+	child = frappe.qb.DocType("Fee Validity Reference")
+
+	return (
+		frappe.qb.from_(fee_validity)
+		.inner_join(child)
+		.on(fee_validity.name == child.parent)
+		.select(fee_validity.name, fee_validity.valid_till)
+		.where(fee_validity.status == "Active")
+		.where(fee_validity.start_date <= date)
+		.where(fee_validity.valid_till >= date)
+		.where(fee_validity.patient == appointment_doc.patient)
+		.where(fee_validity.practitioner == appointment_doc.practitioner)
+		.where(child.appointment == appointment_name)
+	).run(as_dict=True)
+
+
+def update_validity_status():
+	# update the status of fee validity daily
+	validities = frappe.db.get_all("Fee Validity", {"status": ["not in", ["Expired", "Cancelled"]]})
+
+	for fee_validity in validities:
+		fee_validity_doc = frappe.get_doc("Fee Validity", fee_validity.name)
+		fee_validity_doc.update_status()
+		fee_validity_doc.save()

--- a/healthcare/healthcare/doctype/fee_validity/fee_validity_list.js
+++ b/healthcare/healthcare/doctype/fee_validity/fee_validity_list.js
@@ -1,0 +1,12 @@
+frappe.listview_settings['Fee Validity'] = {
+	add_fields: ['practitioner', 'patient', 'status', 'valid_till'],
+	get_indicator: function (doc) {
+		const color = {
+			'Active': 'green',
+			'Completed': 'green',
+			'Expired': 'red',
+			'Cancelled': 'red',
+		};
+		return [__(doc.status), color[doc.status], 'status,=,' + doc.status];
+	}
+}

--- a/healthcare/hooks.py
+++ b/healthcare/hooks.py
@@ -132,6 +132,7 @@ scheduler_events = {
 	],
 	"daily": [
 		"healthcare.healthcare.doctype.patient_appointment.patient_appointment.update_appointment_status",
+		"healthcare.healthcare.doctype.fee_validity.fee_validity.update_validity_status",
 	],
 }
 

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -1,3 +1,4 @@
 healthcare.patches.v0_0.setup_abdm_custom_fields
 healthcare.patches.v0_0.set_medical_code_from_field_to_codification_table
 healthcare.patches.v15_0.check_version_compatibility_with_frappe
+healthcare.patches.v15_0.set_fee_validity_status

--- a/healthcare/patches/v15_0/set_fee_validity_status.py
+++ b/healthcare/patches/v15_0/set_fee_validity_status.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	validities = frappe.db.get_all("Fee Validity", {"status": "Pending"}, as_list=0)
+
+	for fee_validity in validities:
+		frappe.db.set_value("Fee Validity", fee_validity, "status", "Active")


### PR DESCRIPTION
- Insert new Fee Validity for existing patient if not within fee validity
- Status changed to Active(Having free visits left), Expired, Completed (Max visits reached), Cancelled (Appointment Cancelled)
- Scheduler will update the status daily
- First invoiced appointment cancel will cancel fee validity
- Rescheduling the invoiced appointment will update linked fee validity
- Rescheduling the free visit appointment to outside fee validity will Invoice and insert new fee validity