### PR TITLE
fix(Healthcare Service Unit Type): move item creation from after_insert to validate

### DIFF
--- a/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.json
+++ b/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.json
@@ -96,6 +96,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "item.item_name",
    "fieldname": "item_code",
    "fieldtype": "Data",
    "hide_days": 1,
@@ -153,6 +154,7 @@
    "no_copy": 1
   },
   {
+   "fetch_from": "item.description",
    "fieldname": "description",
    "fieldtype": "Small Text",
    "hide_days": 1,
@@ -170,7 +172,7 @@
   }
  ],
  "links": [],
- "modified": "2021-08-19 17:52:30.266667",
+ "modified": "2024-04-29 18:59:16.479821",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Service Unit Type",
@@ -192,5 +194,6 @@
  "restrict_to_domain": "Healthcare",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "service_unit_type"
 }

--- a/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
+++ b/healthcare/healthcare/doctype/healthcare_service_unit_type/healthcare_service_unit_type.py
@@ -39,9 +39,8 @@ class HealthcareServiceUnitType(Document):
 			else:
 				frappe.db.set_value("Item", self.item, "disabled", 0)
 
-	def after_insert(self):
-		if self.inpatient_occupancy and self.is_billable:
-			create_item(self)
+		if self.inpatient_occupancy and self.is_billable and not self.item:
+			self.create_service_unit_item()
 
 	def on_trash(self):
 		if self.item:
@@ -72,10 +71,14 @@ class HealthcareServiceUnitType(Document):
 			frappe.db.set_value("Item", self.item, "disabled", 1)
 		self.reload()
 
+	@frappe.whitelist()
+	def create_service_unit_item(self):
+		create_item(self)
+
 
 def item_price_exists(doc):
 	item_price = frappe.db.exists({"doctype": "Item Price", "item_code": doc.item_code})
-	if len(item_price):
+	if item_price and len(item_price):
 		return item_price[0][0]
 	return False
 

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -326,6 +326,7 @@ frappe.ui.form.on('Patient Encounter', {
 });
 
 var schedule_inpatient = function(frm) {
+	let service_unit_type = "";
 	var dialog = new frappe.ui.Dialog({
 		title: 'Patient Admission',
 		fields: [
@@ -386,6 +387,22 @@ var schedule_inpatient = function(frm) {
 				'allow_appointments': 0
 			}
 		};
+	};
+
+	dialog.fields_dict["service_unit_type"].df.onchange = () => {
+		if (dialog.get_value("service_unit_type") && dialog.get_value("service_unit_type") != service_unit_type) {
+			service_unit_type = dialog.get_value("service_unit_type");
+			frappe.db.get_value("Healthcare Service Unit Type", {name: dialog.get_value("service_unit_type")}, ["is_billable", "item"])
+			.then(r => {
+				if (r.message.is_billable && !r.message.item) {
+					frappe.msgprint({
+						message: __("Selected service unit type doesn't have any item linked"),
+						title: __("Warning"),
+						indicator: "orange",
+					});
+				}
+			})
+		}
 	};
 
 	dialog.show();


### PR DESCRIPTION
- Move item creation from after_insert to validate
- Added button to create/Link existing item to Service Unit Type
- When the time of admission warn if service unit type doesn't linked with an item

![SU_type_fix](https://github.com/frappe/health/assets/89388830/ecefc4d4-5229-4f76-a554-5f27eb45c8cb)
