### PR TITLE
fix: Add source reference to Therapy Plan and populate missing Therapy Session & Clinical Proceedure data

### DIFF
--- a/healthcare/healthcare/doctype/lab_test/lab_test.py
+++ b/healthcare/healthcare/doctype/lab_test/lab_test.py
@@ -320,7 +320,11 @@ def create_sample_doc(template, patient, invoice, company=None):
 			sample_collection = frappe.get_doc("Sample Collection", sample_exists)
 			quantity = int(sample_collection.sample_qty) + int(template.sample_qty)
 			if template.sample_details:
-				sample_details = sample_collection.sample_details + "\n-\n" + _("Test :")
+				sample_details = (
+					(sample_collection.sample_details + "\n-\n")
+					if sample_collection.sample_details
+					else "" + _("Test :")
+				)
 				sample_details += (template.get("lab_test_name") or template.get("template")) + "\n"
 				sample_details += _("Collection Details:") + "\n\t" + template.sample_details
 				frappe.db.set_value(

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.js
@@ -169,6 +169,14 @@ frappe.ui.form.on('Patient Encounter', {
 
 		frm.set_df_property('patient', 'read_only', frm.doc.appointment ? 1 : 0);
 
+		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= frm.doc.encounter_date) {
+			frm.dashboard.set_headline(
+				__("Join video conference with {0}", [
+					`<a target='_blank' href='${frm.doc.google_meet_link}'>Google Meet</a>`,
+				])
+			);
+		}
+
 		if (frappe.meta.get_docfield('Drug Prescription', 'medication').in_list_view === 1) {
 			frm.set_query('drug_code', 'drug_prescription', function(doc, cdt, cdn) {
 				let row = frappe.get_doc(cdt, cdn);

--- a/healthcare/healthcare/doctype/patient_encounter/patient_encounter.json
+++ b/healthcare/healthcare/doctype/patient_encounter/patient_encounter.json
@@ -56,7 +56,6 @@
   "sb_procedures",
   "procedure_prescription",
   "rehabilitation_section",
-  "therapy_plan",
   "therapies",
   "section_break_33",
   "encounter_comment",
@@ -287,14 +286,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "therapy_plan",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Therapy Plan",
-   "options": "Therapy Plan",
-   "read_only": 1
-  },
-  {
    "fieldname": "appointment_type",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
@@ -464,6 +455,7 @@
    "label": "Order History"
   }
  ],
+ "grid_page_length": 50,
  "is_submittable": 1,
  "links": [
   {
@@ -475,7 +467,7 @@
    "link_fieldname": "admission_encounter"
   }
  ],
- "modified": "2023-11-07 18:03:13.793649",
+ "modified": "2025-05-13 18:25:05.874428",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Encounter",
@@ -499,6 +491,7 @@
   }
  ],
  "restrict_to_domain": "Healthcare",
+ "row_format": "Dynamic",
  "search_fields": "patient, practitioner, medical_department, encounter_date, encounter_time",
  "show_name_in_global_search": 1,
  "sort_field": "modified",

--- a/healthcare/healthcare/doctype/service_request/service_request.js
+++ b/healthcare/healthcare/doctype/service_request/service_request.js
@@ -226,8 +226,13 @@ frappe.ui.form.on('Service Request', {
 
 	make_therapy_session: function(frm) {
 		frappe.call({
-			method: 'healthcare.healthcare.doctype.service_request.service_request.make_therapy_session',
-			args: { service_request: frm.doc },
+			method: 'healthcare.healthcare.doctype.therapy_plan.therapy_plan.make_therapy_session',
+			args: {
+				patient: frm.doc.patient,
+				therapy_type: frm.doc.template_dn,
+				company: frm.doc.company,
+				service_request: frm.doc.name
+			},
 			freeze: true,
 			callback: function(r) {
 				var doclist = frappe.model.sync(r.message);

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -213,42 +213,6 @@ def make_lab_test(service_request):
 
 
 @frappe.whitelist()
-def make_therapy_session(service_request):
-	if isinstance(service_request, string_types):
-		service_request = json.loads(service_request)
-		service_request = frappe._dict(service_request)
-
-	if (
-		frappe.db.get_single_value("Healthcare Settings", "process_service_request_only_if_paid")
-		and service_request.billing_status != "Invoiced"
-	):
-		frappe.throw(
-			_("Service Request need to be invoiced before proceeding"),
-			title=_("Payment Required"),
-		)
-
-	doc = frappe.new_doc("Therapy Session")
-	doc.therapy_type = service_request.template_dn
-	doc.service_request = service_request.name
-	doc.company = service_request.company
-	doc.patient = service_request.patient
-	doc.patient_name = service_request.patient_name
-	doc.gender = service_request.patient_gender
-	doc.patient_age = service_request.patient_age_data
-	doc.practitioner = service_request.practitioner
-	doc.department = service_request.medical_department
-	doc.start_date = service_request.occurrence_date
-	doc.start_time = service_request.occurrence_time
-	doc.invoiced = service_request.invoiced
-	doc.insurance_policy = service_request.insurance_policy
-	doc.insurance_payor = service_request.insurance_payor
-	doc.insurance_coverage = service_request.insurance_coverage
-	doc.coverage_status = service_request.coverage_status
-
-	return doc
-
-
-@frappe.whitelist()
 def make_observation(service_request):
 	if isinstance(service_request, string_types):
 		service_request = json.loads(service_request)

--- a/healthcare/healthcare/doctype/service_request/service_request.py
+++ b/healthcare/healthcare/doctype/service_request/service_request.py
@@ -152,6 +152,8 @@ def make_clinical_procedure(service_request):
 			title=_("Payment Required"),
 		)
 
+	procedure_template = frappe.get_doc("Clinical Procedure Template", service_request.template_dn)
+
 	doc = frappe.new_doc("Clinical Procedure")
 	doc.procedure_template = service_request.template_dn
 	doc.service_request = service_request.name
@@ -169,6 +171,22 @@ def make_clinical_procedure(service_request):
 	doc.insurance_payor = service_request.insurance_payor
 	doc.insurance_coverage = service_request.insurance_coverage
 	doc.coverage_status = service_request.coverage_status
+	doc.consume_stock = procedure_template.consume_stock
+	doc.warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
+
+	if not doc.codification_table and procedure_template.codification_table:
+		for code in procedure_template.codification_table:
+			doc.append(
+				"codification_table",
+				(frappe.copy_doc(code)).as_dict(),
+			)
+
+	if not doc.items and procedure_template.items:
+		for item in procedure_template.items:
+			doc.append(
+				"items",
+				(frappe.copy_doc(item)).as_dict(),
+			)
 
 	return doc
 

--- a/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
@@ -36,11 +36,11 @@ class TestTherapyPlan(IntegrationTestCase):
 		plan = create_therapy_plan()
 		self.assertEqual(plan.status, "Not Started")
 
-		session = make_therapy_session(plan.name, plan.patient, "Basic Rehab", "_Test Company")
+		session = make_therapy_session(plan.patient, "Basic Rehab", "_Test Company", plan.name)
 		frappe.get_doc(session).submit()
 		self.assertEqual(frappe.db.get_value("Therapy Plan", plan.name, "status"), "In Progress")
 
-		session = make_therapy_session(plan.name, plan.patient, "Basic Rehab", "_Test Company")
+		session = make_therapy_session(plan.patient, "Basic Rehab", "_Test Company", plan.name)
 		frappe.get_doc(session).submit()
 		self.assertEqual(frappe.db.get_value("Therapy Plan", plan.name, "status"), "Completed")
 
@@ -48,7 +48,7 @@ class TestTherapyPlan(IntegrationTestCase):
 		appointment = create_appointment(patient, practitioner, nowdate())
 
 		session = make_therapy_session(
-			plan.name, plan.patient, "Basic Rehab", "_Test Company", appointment.name
+			plan.patient, "Basic Rehab", "_Test Company", plan.name, appointment.name
 		)
 		session = frappe.get_doc(session)
 		session.submit()

--- a/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
+++ b/healthcare/healthcare/doctype/therapy_plan/test_therapy_plan.py
@@ -26,7 +26,11 @@ class TestTherapyPlan(IntegrationTestCase):
 		patient, practitioner = create_healthcare_docs()
 		medical_department = create_medical_department()
 		encounter = create_encounter(patient, medical_department, practitioner)
-		self.assertTrue(frappe.db.exists("Therapy Plan", encounter.therapy_plan))
+		self.assertTrue(
+			frappe.db.exists(
+				"Therapy Plan", {"source_doc": "Patient Encounter", "order_group": encounter.name}
+			)
+		)
 
 	def test_status(self):
 		plan = create_therapy_plan()

--- a/healthcare/healthcare/doctype/therapy_plan/therapy_plan.json
+++ b/healthcare/healthcare/doctype/therapy_plan/therapy_plan.json
@@ -21,7 +21,10 @@
   "section_break_9",
   "total_sessions",
   "column_break_11",
-  "total_sessions_completed"
+  "total_sessions_completed",
+  "more_information_section",
+  "source_doc",
+  "order_group"
  ],
  "fields": [
   {
@@ -126,13 +129,37 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "more_information_section",
+   "fieldtype": "Section Break",
+   "label": "More Information"
+  },
+  {
+   "fieldname": "source_doc",
+   "fieldtype": "Link",
+   "label": "Source Doc",
+   "no_copy": 1,
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "order_group",
+   "fieldtype": "Dynamic Link",
+   "label": "Order Group",
+   "no_copy": 1,
+   "options": "source_doc",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2020-11-04 18:13:13.564999",
+ "modified": "2025-05-13 17:46:15.837432",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Plan",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -171,9 +198,11 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "patient",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "patient",
  "track_changes": 1
 }

--- a/healthcare/patches.txt
+++ b/healthcare/patches.txt
@@ -20,3 +20,4 @@ healthcare.patches.v15_0.set_allow_booking_for_in_appointment_type
 healthcare.patches.v15_0.setup_basic_code_systems
 healthcare.patches.v15_0.setup_diagnostic_module_codes
 healthcare.patches.v15_0.setup_order_status_codes
+healthcare.patches.v15_0.set_reference_in_therapy_plan

--- a/healthcare/patches/v15_0/set_reference_in_therapy_plan.py
+++ b/healthcare/patches/v15_0/set_reference_in_therapy_plan.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+	therapy_plans = frappe.db.get_all("Therapy Plan", pluck="name")
+
+	for plan in therapy_plans:
+		encounter = frappe.db.exists("Patient Encounter", {"therapy_plan": plan}, "name")
+		if encounter:
+			frappe.db.set_value(
+				"Therapy Plan",
+				plan,
+				{"source_doc": "Patient Encounter", "order_group": encounter},
+				update_modified=False,
+			)


### PR DESCRIPTION
- Add "source_doc" & "order_group" fields in Therapy Plan to link Patient Encounter and patch to set references in Therapy Plan
- Populate missing Therapy session data when creating from Therapy Plan or Service Request
- Populate missing Clinical Proceedure data when creating from Service Request